### PR TITLE
Add Linux build workflow and remove ISO file in order to execute the build on GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build osakaOS
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update # && sudo apt-get upgrade -y
+          sudo apt-get install -y build-essential binutils libc6-dev-i386 g++ mtools
+          sudo apt-get install -y qemu-system-x86 grub2 xorriso
+
+      - name: Build osakaOS
+        run: |
+          make -j8 osakaOS.bin
+          make -j8 osakaOS.iso
+        env:
+          ARCHIVE: 1
+
+      - name: Store ISO build
+        uses: actions/upload-artifact@v4
+        with:
+          name: osakaOS_build
+          path: osakaOS.iso
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Publish a release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          files: |
+            *.iso


### PR DESCRIPTION
That builds everytime you push a commit, so the action runs. After building, you get the artifact (the compiled ISO file).

Go to Actions:
<img src="https://github.com/user-attachments/assets/34fe6938-dec5-4f13-8c11-3bfd624ed05a" alt="gh_actions" />

Select a workflow (it will display the commit message, even if the workflow is running):
<img src="https://github.com/user-attachments/assets/82869e45-68ac-4cc5-8f6f-79732929de35" alt="workflow_runs" />

And download the artifact (it's compressed with .zip):
<img src="https://github.com/user-attachments/assets/4348c291-61bb-4e11-a7a9-2f45ab7065a5" alt="artifact" />

Keep in mind, the build workflow on artifact storage retention, so it expires after x days. I set the expiration to 7 days (one week), it can be changed on this line:
https://github.com/pac-ac/osakaOS/commit/6cf73aa#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R29
